### PR TITLE
chore: make terraform helm provider output readable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,6 +61,7 @@ tasks:
           enum: [ digitalocean, kind ]
     sources:
       - provision/{{.CLOUD_PROVIDER}}/terraform.tfvars.json
+      - provision/{{.CLOUD_PROVIDER}}/*.tfvars
       - provision/{{.CLOUD_PROVIDER}}/*.tf
 
   deploy:

--- a/config/default.jsonnet
+++ b/config/default.jsonnet
@@ -10,10 +10,10 @@
     enable_reflector: false, // a controller for syncing resources between namespaces
     enable_argo_workflows: false, // a controller for running Argo Workflows
   },
-  argo_cd_chart_version: '7.8.14',
+  argo_cd_chart_version: '8.0.10',
   use_custom_argocd_image: true, // If true, will use the custom image for repo-server
   custom_argocd_image: 'ghcr.io/shini4i/argocd',
-  custom_argocd_image_tag: 'v2.14.8',
+  custom_argocd_image_tag: 'v3.0.3',
   argo_watcher_chart_version: '0.8.0',
   argo_watcher_enabled: false,
   argo_watcher_persistence_enabled: false, // If true, will deploy postgresql and use it for persistence

--- a/deploy/argocd/providers.tf
+++ b/deploy/argocd/providers.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "2.16.1"
+      version = "2.17.0"
     }
   }
 }

--- a/deploy/main.tf
+++ b/deploy/main.tf
@@ -9,7 +9,7 @@ terraform {
 
     helm = {
       source  = "hashicorp/helm"
-      version = "2.16.1"
+      version = "2.17.0"
     }
 
     argocd = {

--- a/deploy/providers.tf
+++ b/deploy/providers.tf
@@ -6,6 +6,10 @@ provider "helm" {
   kubernetes {
     config_path = "../kubeconfig"
   }
+  experiments {
+    # enables diff support of kubernetes manifests rendered by helm
+    manifest = true
+  }
 }
 
 provider "argocd" {

--- a/provision/kind/terraform.tfvars
+++ b/provision/kind/terraform.tfvars
@@ -1,1 +1,1 @@
-kindest_node_version = "v1.32.2"
+kindest_node_version = "v1.32.5"


### PR DESCRIPTION
These changes makes possible to understand changes per k8s resource instead of pure values diff. Also bumps version here and there.