### PR TITLE
chore: minor argo stack tuning

### DIFF
--- a/config/default.jsonnet
+++ b/config/default.jsonnet
@@ -9,6 +9,7 @@
     enable_sealed_secrets: false, // a controller for encrypting secrets to safely store them in a Git repository
     enable_reflector: false, // a controller for syncing resources between namespaces
     enable_argo_workflows: false, // a controller for running Argo Workflows
+    enable_argo_rollouts: false, // a controller for managing progressive delivery with Argo Rollouts
   },
   argo_cd_chart_version: '8.0.10',
   use_custom_argocd_image: true, // If true, will use the custom image for repo-server

--- a/deploy/argo-watcher/README.md
+++ b/deploy/argo-watcher/README.md
@@ -30,6 +30,7 @@ No modules.
 | [kubernetes_manifest.postgres](https://registry.terraform.io/providers/hashicorp/kubernetes/2.33.0/docs/resources/manifest) | resource |
 | [kubernetes_manifest.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.33.0/docs/resources/manifest) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.33.0/docs/resources/namespace) | resource |
+| [kubernetes_secret.postgres_credentials](https://registry.terraform.io/providers/hashicorp/kubernetes/2.33.0/docs/resources/secret) | resource |
 | [kubernetes_secret.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.33.0/docs/resources/secret) | resource |
 | [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |

--- a/deploy/argo-watcher/main.tf
+++ b/deploy/argo-watcher/main.tf
@@ -79,7 +79,7 @@ resource "kubernetes_manifest" "this" {
     persistence_enabled = var.persistence_enabled
     secretName          = kubernetes_secret.this.metadata[0].name
     namespace           = kubernetes_namespace.this.metadata[0].name
-    postgresSecretName  = var.persistence_enabled ? kubernetes_secret.postgres_credentials.metadata[0].name : ""
+    postgresSecretName  = var.persistence_enabled ? kubernetes_secret.postgres_credentials.metadata[0].name : "dummy-value"
   }))
 
   wait {

--- a/deploy/argo-watcher/templates/argo-watcher-psql.tftpl
+++ b/deploy/argo-watcher/templates/argo-watcher-psql.tftpl
@@ -23,6 +23,7 @@ spec:
           enablePostgresUser: false
           username: watcher
           database: watcher
+          existingSecret: ${secretName}
         primary:
           persistence:
             enabled: true

--- a/deploy/argo-watcher/templates/argo-watcher.tftpl
+++ b/deploy/argo-watcher/templates/argo-watcher.tftpl
@@ -52,7 +52,7 @@ spec:
           host: argo-watcher-psql
           name: watcher
           user: watcher
-          secretName: argo-watcher-psql
+          secretName: ${postgresSecretName}
           secretKey: password
 
   destination:

--- a/deploy/argocd/README.md
+++ b/deploy/argocd/README.md
@@ -6,7 +6,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.8 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.16.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | 2.17.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | 2.33.0 |
 
 ## Providers
@@ -24,7 +24,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/2.16.1/docs/resources/release) | resource |
+| [helm_release.this](https://registry.terraform.io/providers/hashicorp/helm/2.17.0/docs/resources/release) | resource |
 | [kubernetes_manifest.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.33.0/docs/resources/manifest) | resource |
 | [kubernetes_namespace.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.33.0/docs/resources/namespace) | resource |
 | [kubernetes_secret_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/2.33.0/docs/resources/secret_v1) | resource |

--- a/deploy/argocd/main.tf
+++ b/deploy/argocd/main.tf
@@ -41,7 +41,8 @@ resource "helm_release" "this" {
         use_custom_argocd_image  = var.use_custom_argocd_image
         custom_argocd_image      = var.custom_argocd_image
         custom_argocd_image_tag  = var.custom_argocd_image_tag
-      }))
+        argo_rollouts_enabled    = var.argocd_applicationset_addons.enable_argo_rollouts
+    }))
   ]
 
   depends_on = [

--- a/deploy/argocd/templates/argo-cd.tftpl
+++ b/deploy/argocd/templates/argo-cd.tftpl
@@ -22,6 +22,13 @@ server:
       - hosts:
           - ${fqdn}
         secretName: argo-cd-tls
+  extensions:
+    enabled: true
+    extensionList:
+      - name: rollout-extension
+        env:
+          - name: EXTENSION_URL
+            value: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar
 
 %{ if use_custom_argocd_image == true }
 repoServer:

--- a/deploy/argocd/templates/argo-cd.tftpl
+++ b/deploy/argocd/templates/argo-cd.tftpl
@@ -22,6 +22,7 @@ server:
       - hosts:
           - ${fqdn}
         secretName: argo-cd-tls
+%{ if argo_rollouts_enabled == true }
   extensions:
     enabled: true
     extensionList:
@@ -29,6 +30,7 @@ server:
         env:
           - name: EXTENSION_URL
             value: https://github.com/argoproj-labs/rollout-extension/releases/download/v0.3.7/extension.tar
+%{ endif ~}
 
 %{ if use_custom_argocd_image == true }
 repoServer:

--- a/deploy/ingress-controller/templates/ingress-nginx.tftpl
+++ b/deploy/ingress-controller/templates/ingress-nginx.tftpl
@@ -19,6 +19,8 @@ spec:
 
         controller:
           watchIngressWithoutClass: true
+          config:
+            enable-underscores-in-headers: "true" # this is required for argo-watcher
         %{ if local_setup == true }
           service:
             type: NodePort


### PR DESCRIPTION
This MR introduces the following changes:
- PostgreSQL based `argo-watcher` setup does not break after cluster restart
- Adds `argo rollouts` extension to argocd ui
- Adds `enable-underscores-in-headers` to `ingress-nginx` for `argo-watcher` support
- Add a feature toggle for deploying `argo-rollouts`